### PR TITLE
docs: add Docker Compose usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,22 +18,65 @@ While many web-based IDE solutions exist, most are built on the "Code OSS" (Open
 
 ## 🛠 Usage
 
-### 1. Pull the Image
+You can run this image either locally with Docker/Docker Compose or on Kubernetes with the Helm chart.
 
-```plaintext
+### Option A: Run with Docker
+
+Pull the image:
+
+```bash
 docker pull antiantiops/vscode-browser-docker:latest
 ```
 
-### 2. Run the Container
+Run the container:
 
-```plaintext
-docker run -it -p 8000:8000 \
-  -v $(pwd):/home/coder/project \
+```bash
+docker run -it --rm \
+  --name openvscode-server \
+  -p 8000:8000 \
+  -v "$(pwd)/workspace:/home/antiantiops/project" \
   antiantiops/vscode-browser-docker:latest
 ```
 
-* **Access the IDE:** Open your browser and navigate to `http://localhost:8000`.
-* **Persist Data:** The command above maps your current directory to `/home/coder/project`. Any changes made inside that folder will be saved to your host machine.
+Open your browser and navigate to:
+
+```text
+http://localhost:8000
+```
+
+The command above mounts `./workspace` from your host to `/home/antiantiops/project` inside the container. Files created there are persisted on your host machine.
+
+### Option B: Run with Docker Compose
+
+Create the local workspace directory:
+
+```bash
+mkdir -p workspace
+```
+
+Start VS Code Server:
+
+```bash
+docker compose up -d
+```
+
+Open:
+
+```text
+http://localhost:8000
+```
+
+Stop it when finished:
+
+```bash
+docker compose down
+```
+
+This repository includes a ready-to-use [`docker-compose.yml`](docker-compose.yml) that:
+
+* exposes VS Code Server on port `8000`
+* mounts `./workspace` to `/home/antiantiops/project`
+* keeps `/home/antiantiops` data in a named Docker volume (`openvscode-home`)
 
 ## ⚙️ Configuration
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  openvscode-server:
+    image: antiantiops/vscode-browser-docker:latest
+    container_name: openvscode-server
+    ports:
+      - "8000:8000"
+    volumes:
+      # Workspace mounted inside VS Code Server.
+      - ./workspace:/home/antiantiops/project
+      # Optional: persist VS Code/user data across container restarts.
+      - openvscode-home:/home/antiantiops
+    restart: unless-stopped
+
+volumes:
+  openvscode-home:


### PR DESCRIPTION
## Summary
- add docker-compose.yml for running VS Code Server locally
- document Docker and Docker Compose usage in README
- fix workspace path to /home/antiantiops/project

## Test
- docker compose config validated on 192.168.101.36

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rewrote Usage section with explicit Docker and Docker Compose setup instructions
  * Clarified port access, workspace mounting, and data persistence details

* **Chores**
  * Added Docker Compose configuration for streamlined deployment

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mrnim94/openvscode-server-helm/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->